### PR TITLE
Added hero inventory information to "interval" type of entry

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -2,7 +2,6 @@ package opendota;
 
 import com.google.gson.Gson;
 import com.google.protobuf.GeneratedMessage;
-import com.sun.istack.internal.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import skadistats.clarity.decoder.Util;

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -497,7 +497,6 @@ public class Parse {
         }
     }
 
-    @Nullable
     private List<String> getHeroInventory(Context ctx, Entity eHero) {
         List<String> inventoryList = new ArrayList<>(6);
         StringTable stEntityNames = ctx.getProcessor(StringTables.class).forName("EntityNames");


### PR DESCRIPTION
The idea behind this change is to calculate "effective" or "item" networth.
Still need to cover special cases for heroes like Lone Druid, stolen/shared and consumed items.
Does sending that info is too spammy for 1 sec interval?