### PR TITLE
bounty hunter track and greevils greed stack status

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import opendota.combatlogvisitors.CombatLogVisitors;
+import opendota.combatlogvisitors.VisitorResult;
 
 public class Parse {
 
@@ -314,7 +315,10 @@ public class Parse {
             else if (cle.getType() == DOTA_COMBATLOG_TYPES.DOTA_COMBATLOG_XP) {
                 combatLogEntry.xp_reason = cle.getXpReason();
             }
-            combatLogVisitors.visit(combatLogEntry);
+            
+            VisitorResult result = combatLogVisitors.visit(combatLogEntry);
+            combatLogEntry.greevils_greed_stack = result.greevilsGreedStack;
+            combatLogEntry.tracked_death = result.trackedDeath;
 
             output(combatLogEntry);
             

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -33,9 +33,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import opendota.combatlogvisitors.CombatLogVisitors;
+
 public class Parse {
 
-	private class Entry {
+	public class Entry {
 		public Integer time;
 		public String type;
 		public Integer team;
@@ -90,6 +92,8 @@ public class Parse {
 		public Boolean pred_vict;
 		public Float stun_duration;
 		public Float slow_duration;
+		public Boolean tracked_death;
+		public Integer greevils_greed_stack;
 		
 		public Entry() {
 		}
@@ -129,9 +133,12 @@ public class Parse {
 	HashMap<Integer, Integer> cosmeticsMap = new HashMap<Integer, Integer>();
     InputStream is = null;
     OutputStream os = null;
+	private CombatLogVisitors combatLogVisitors;
     
     public Parse(InputStream input, OutputStream output) throws IOException
     {
+      combatLogVisitors = new CombatLogVisitors(name_to_slot);
+    	
       is = input;
       os = output;
       long tStart = System.currentTimeMillis();
@@ -307,6 +314,8 @@ public class Parse {
             else if (cle.getType() == DOTA_COMBATLOG_TYPES.DOTA_COMBATLOG_XP) {
                 combatLogEntry.xp_reason = cle.getXpReason();
             }
+            combatLogVisitors.visit(combatLogEntry);
+
             output(combatLogEntry);
             
             if (cle.getType().ordinal() > 19) {

--- a/src/main/java/opendota/combatlogvisitors/BountyHunterTrackVisitor.java
+++ b/src/main/java/opendota/combatlogvisitors/BountyHunterTrackVisitor.java
@@ -1,0 +1,29 @@
+package opendota.combatlogvisitors;
+
+import static opendota.combatlogvisitors.CombatLogConstants.DOTA_COMBATLOG_DEATH;
+import static opendota.combatlogvisitors.CombatLogConstants.DOTA_COMBATLOG_MODIFIER_ADD;
+import static opendota.combatlogvisitors.CombatLogConstants.DOTA_COMBATLOG_MODIFIER_REMOVE;
+
+import java.util.HashMap;
+
+import opendota.Parse.Entry;
+
+public class BountyHunterTrackVisitor implements Visitor {
+
+	private static final String BH_TRACK = "modifier_bounty_hunter_track";
+	
+	HashMap<String, Boolean> trackStatus = new HashMap<String, Boolean>();
+
+	@Override
+	public void visit(Entry entry) {
+        if (entry.type.equals(DOTA_COMBATLOG_MODIFIER_ADD) && entry.inflictor.equals(BH_TRACK))
+			trackStatus.put(entry.targetname, true);
+        
+        if (entry.type.equals(DOTA_COMBATLOG_MODIFIER_REMOVE) && entry.inflictor.equals(BH_TRACK))
+			trackStatus.put(entry.targetname, false);
+        
+        if (entry.type.equals(DOTA_COMBATLOG_DEATH))
+			if (trackStatus.getOrDefault(entry.targetname, false))
+				entry.tracked_death = true; 
+	}
+}

--- a/src/main/java/opendota/combatlogvisitors/BountyHunterTrackVisitor.java
+++ b/src/main/java/opendota/combatlogvisitors/BountyHunterTrackVisitor.java
@@ -15,7 +15,7 @@ public class BountyHunterTrackVisitor implements Visitor {
 	HashMap<String, Boolean> trackStatus = new HashMap<String, Boolean>();
 
 	@Override
-	public void visit(Entry entry) {
+	public void visit(Entry entry, VisitorResult result) {
         if (entry.type.equals(DOTA_COMBATLOG_MODIFIER_ADD) && entry.inflictor.equals(BH_TRACK))
 			trackStatus.put(entry.targetname, true);
         
@@ -24,6 +24,6 @@ public class BountyHunterTrackVisitor implements Visitor {
         
         if (entry.type.equals(DOTA_COMBATLOG_DEATH))
 			if (trackStatus.getOrDefault(entry.targetname, false))
-				entry.tracked_death = true; 
+				result.trackedDeath = true; 
 	}
 }

--- a/src/main/java/opendota/combatlogvisitors/CombatLogConstants.java
+++ b/src/main/java/opendota/combatlogvisitors/CombatLogConstants.java
@@ -1,0 +1,8 @@
+package opendota.combatlogvisitors;
+
+public class CombatLogConstants {
+
+	public static final String DOTA_COMBATLOG_MODIFIER_ADD = "DOTA_COMBATLOG_MODIFIER_ADD";
+	public static final String DOTA_COMBATLOG_MODIFIER_REMOVE = "DOTA_COMBATLOG_MODIFIER_REMOVE";
+	public static final String DOTA_COMBATLOG_DEATH = "DOTA_COMBATLOG_DEATH";
+}

--- a/src/main/java/opendota/combatlogvisitors/CombatLogVisitors.java
+++ b/src/main/java/opendota/combatlogvisitors/CombatLogVisitors.java
@@ -14,8 +14,11 @@ public class CombatLogVisitors {
 		visitors = Arrays.asList(new BountyHunterTrackVisitor(),new GreevilsGreedVisitor(nameToSlot));
 	}
 	
-	public void visit(Entry entry) {
-		for (Visitor v : visitors)
-			v.visit(entry);
+	public VisitorResult visit(Entry entry) {
+		VisitorResult result = new VisitorResult(); 
+		for (Visitor v : visitors) {
+			v.visit(entry, result);
+		}
+		return result;
 	}
 }

--- a/src/main/java/opendota/combatlogvisitors/CombatLogVisitors.java
+++ b/src/main/java/opendota/combatlogvisitors/CombatLogVisitors.java
@@ -1,0 +1,21 @@
+package opendota.combatlogvisitors;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import opendota.Parse.Entry;
+
+public class CombatLogVisitors {
+
+	final List<Visitor> visitors;
+	
+	public CombatLogVisitors(HashMap<String, Integer> nameToSlot) {
+		visitors = Arrays.asList(new BountyHunterTrackVisitor(),new GreevilsGreedVisitor(nameToSlot));
+	}
+	
+	public void visit(Entry entry) {
+		for (Visitor v : visitors)
+			v.visit(entry);
+	}
+}

--- a/src/main/java/opendota/combatlogvisitors/GreevilsGreedVisitor.java
+++ b/src/main/java/opendota/combatlogvisitors/GreevilsGreedVisitor.java
@@ -23,7 +23,7 @@ public class GreevilsGreedVisitor implements Visitor {
 	}
 
 	@Override
-	public void visit(Entry entry) {
+	public void visit(Entry entry, VisitorResult result) {
         if (entry.type.equals(DOTA_COMBATLOG_MODIFIER_ADD)
         		&& entry.attackername.equals("npc_dota_hero_alchemist")
         		&& entry.inflictor.equals("modifier_alchemist_goblins_greed")
@@ -48,7 +48,7 @@ public class GreevilsGreedVisitor implements Visitor {
         		}
         	}
         	
-			entry.greevils_greed_stack = lastHitTimings.size();
+			result.greevilsGreedStack = lastHitTimings.size();
         	
         	lastHitTimings.add(entry.time);
         }

--- a/src/main/java/opendota/combatlogvisitors/GreevilsGreedVisitor.java
+++ b/src/main/java/opendota/combatlogvisitors/GreevilsGreedVisitor.java
@@ -1,0 +1,62 @@
+package opendota.combatlogvisitors;
+
+import static opendota.combatlogvisitors.CombatLogConstants.DOTA_COMBATLOG_MODIFIER_ADD;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import opendota.Parse.Entry;
+
+public class GreevilsGreedVisitor implements Visitor {
+
+    private static final int GREEVILS_GREED_WINDOW = 30;
+    
+	private boolean greevilsGreedLearned = false;
+    private Set<Integer> lastHitTimings = new HashSet<>();
+    
+	private HashMap<String, Integer> nameToSlot; 
+    
+	public GreevilsGreedVisitor(HashMap<String, Integer> nameToSlot) {
+		this.nameToSlot = nameToSlot;
+	}
+
+	@Override
+	public void visit(Entry entry) {
+        if (entry.type.equals(DOTA_COMBATLOG_MODIFIER_ADD)
+        		&& entry.attackername.equals("npc_dota_hero_alchemist")
+        		&& entry.inflictor.equals("modifier_alchemist_goblins_greed")
+        		&& !entry.attackerillusion) {
+        	greevilsGreedLearned = true;
+        }
+        
+        if (greevilsGreedLearned
+        		&& entry.type.equals(CombatLogConstants.DOTA_COMBATLOG_DEATH)
+        		&& entry.attackername.equals("npc_dota_hero_alchemist")
+        		&& !entry.attackerillusion) {
+
+        	if (isDeny(entry.targetname))
+        		return;
+        	
+        	Iterator<Integer> iterator = lastHitTimings.iterator();
+			while(iterator.hasNext()) {
+        		Integer lhTiming = iterator.next();
+				boolean isExpired = lhTiming + GREEVILS_GREED_WINDOW < entry.time;
+				if (isExpired) {
+        			iterator.remove();
+        		}
+        	}
+        	
+			entry.greevils_greed_stack = lastHitTimings.size();
+        	
+        	lastHitTimings.add(entry.time);
+        }
+	}
+	
+	private boolean isDeny(String targetName) {
+		String creepAllied = nameToSlot.get("npc_dota_hero_alchemist") < 5 ? "goodguys" : "badguys";
+		return targetName.contains(creepAllied);
+	}
+
+}

--- a/src/main/java/opendota/combatlogvisitors/Visitor.java
+++ b/src/main/java/opendota/combatlogvisitors/Visitor.java
@@ -4,5 +4,5 @@ import opendota.Parse.Entry;
 
 public interface Visitor {
 
-	void visit(Entry entry);
+	void visit(Entry entry, VisitorResult result);
 }

--- a/src/main/java/opendota/combatlogvisitors/Visitor.java
+++ b/src/main/java/opendota/combatlogvisitors/Visitor.java
@@ -1,0 +1,8 @@
+package opendota.combatlogvisitors;
+
+import opendota.Parse.Entry;
+
+public interface Visitor {
+
+	void visit(Entry entry);
+}

--- a/src/main/java/opendota/combatlogvisitors/VisitorResult.java
+++ b/src/main/java/opendota/combatlogvisitors/VisitorResult.java
@@ -1,0 +1,7 @@
+package opendota.combatlogvisitors;
+
+public class VisitorResult {
+
+	public Integer greevilsGreedStack;
+	public Boolean trackedDeath;
+}


### PR DESCRIPTION
My intention here is to track how much gold Alchemist Greevils Greed and Track kills increased their gold.
Since we don't have info about skill lvl, in the parser we'll just track the info about it, and then in the api it would be possible to cross this info with skills lvl to determine how much gold alch and bh team got increased due to greevils greed and track.

Greevils Greed expires every 30 seconds from the LH, se we track all last hits alch has done lasts 30 seconds to determine how much stacks greevils greed provided for the current last hit.

Track we just check when the track modifier got add/removed from a hero, and check it when it got killed. Track is a great way of comebacks, I think this info would be great.