### PR TITLE
remade starting items tracking

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -540,8 +540,7 @@ public class Parse {
                             name_to_slot.put(combatLogName2, entry.slot);
 
                             entry.hero_inventory = getHeroInventory(ctx, e);
-                            entry.hero_inventory = getHeroInventory(ctx, e);
-                            if (entry.hero_inventory != null && !isPlayerStartingItemsWritten.get(entry.slot)) {
+                            if (!isPlayerStartingItemsWritten.get(entry.slot)) {
                                 // Making something similar to DOTA_COMBATLOG_PURCHASE for each item in the beginning of the game
                                 isPlayerStartingItemsWritten.set(entry.slot, true);
                                 for (Item item : entry.hero_inventory) {

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -148,7 +148,7 @@ public class Parse {
     	
       is = input;
       os = output;
-      isPlayerStartingItemsWritten = new ArrayList<>(Arrays.asList(new Boolean[10]));
+      isPlayerStartingItemsWritten = new ArrayList<>(Arrays.asList(new Boolean[numPlayers]));
       Collections.fill(isPlayerStartingItemsWritten, Boolean.FALSE);
       long tStart = System.currentTimeMillis();
       new SimpleRunner(new InputStreamSource(is)).runWith(this);


### PR DESCRIPTION
I've found another bug in starting items. Look at tinker inventory in the beginnig of the game
https://www.opendota.com/matches/3185429370/purchases
https://www.dotabuff.com/matches/3185429370/builds

Also i checked it in Dota 2 client. Tinker bought null talisman before the game starts, but in parsed json it is showed like that:

{"time":317,"type":"actions","key":"16","value":20,"slot":5,"unit_list":[],"x":307,"y":216}
{"time":317,"type":"actions","key":"16","value":15,"slot":5,"unit_list":[],"x":307,"y":216}
{"time":317,"type":"actions","key":"16","value":76,"slot":5,"unit_list":[],"x":307,"y":216}

values 20, 15 and 76 stays for item_circlet, item_mantle, and item_recipe_null_talisman.
And since these items were boughts before the start of the game, we get no DOTA_COMBATLOG events. I guess, that's why opendota don't track purchace of complex items: because DOTA_COMBATLOG registers it as item purchase and actions as item_recipe purchace.

for example, slark bought wraith's band at 5:06 and DOTA_COMBATLOG got event like

{"time":726,"type":"actions","key":"16","value":74,"slot":3,"unit_list":[930],"x":449,"y":345}

{"time":726,"type":"DOTA_COMBATLOG_PURCHASE","value":128,"attackername":"dota_unknown","targetname":"npc_dota_hero_slark","sourcename":"dota_unknown","targetsourcename":"dota_unknown","attackerhero":false,"targethero":false,"attackerillusion":false,"targetillusion":false,"inflictor":"dota_unknown","valuename":"item_wraith_band"}
{"time":726,"type":"DOTA_COMBATLOG_PURCHASE","value":129,"attackername":"dota_unknown","targetname":"npc_dota_hero_slark","sourcename":"dota_unknown","targetsourcename":"dota_unknown","attackerhero":false,"targethero":false,"attackerillusion":false,"targetillusion":false,"inflictor":"dota_unknown","valuename":"item_recipe_wraith_band"}

The suggested solution is to check everyones inventory right after the game started and write iventories as DOTA_COMBATLOG_PURCHASE (like they were bought at the start of the game).

Since now we track all items that were bought before the start of the game via DOTA_COMBATLOG_PURCHASE, we don't need to track these purchases in actions. I also removed some code related to this in processorExpand in odota/core (https://github.com/odota/core/pull/1472)