### PR TITLE
Add missing stages in the draft

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -180,7 +180,7 @@ public class Parse {
     private ArrayList<Entry> logBuffer = new ArrayList<Entry>();
 
     //Draft stage variable
-    boolean[] draftOrderProcessed = new boolean[22];
+    boolean[] draftOrderProcessed = new boolean[24];
     int order = 1;
     boolean isDraftStartTimeProcessed = false; //flag to know if draft start time is already handled
 
@@ -514,7 +514,7 @@ public class Parse {
 
                 //Picks and ban are not in order due to draft change rules changes between patches
                 // Need to listen for the picks and ban to change
-                int[] draftHeroes = new int[22];
+                int[] draftHeroes = new int[24];
                 draftHeroes[0] = getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0000", null);
                 draftHeroes[1] = getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0001", null);
                 draftHeroes[2] = getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0002", null);
@@ -528,16 +528,18 @@ public class Parse {
                 // Apparently Drafts go to 6 bans now, but have returns of null
                 draftHeroes[10] = getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0010", null) == null ? 0 : getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0010", null);
                 draftHeroes[11] = getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0011", null) == null ? 0 : getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0011", null);
-                draftHeroes[12] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0000", null);
-                draftHeroes[13] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0001", null);
-                draftHeroes[14] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0002", null);
-                draftHeroes[15] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0003", null);
-                draftHeroes[16] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0004", null);
-                draftHeroes[17] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0005", null);
-                draftHeroes[18] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0006", null);
-                draftHeroes[19] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0007", null);
-                draftHeroes[20] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0008", null);
-                draftHeroes[21] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0009", null);
+                draftHeroes[12] = getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0012", null) == null ? 0 : getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0012", null);
+                draftHeroes[13] = getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0013", null) == null ? 0 : getEntityProperty(grp, "m_pGameRules.m_BannedHeroes.0013", null);
+                draftHeroes[14] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0000", null);
+                draftHeroes[15] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0001", null);
+                draftHeroes[16] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0002", null);
+                draftHeroes[17] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0003", null);
+                draftHeroes[18] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0004", null);
+                draftHeroes[19] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0005", null);
+                draftHeroes[20] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0006", null);
+                draftHeroes[21] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0007", null);
+                draftHeroes[22] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0008", null);
+                draftHeroes[23] = getEntityProperty(grp, "m_pGameRules.m_SelectedHeroes.0009", null);
                 //Once a pick or ban happens grab the time and extra time remaining for both teams
                 for(int i = 0; i < draftHeroes.length; i++) {
                     if(draftHeroes[i] > 0 && draftOrderProcessed[i] ==  false) {
@@ -547,7 +549,7 @@ public class Parse {
                         draftTimingsEntry.type = "draft_timings";
                         draftTimingsEntry.draft_order = order;
                         order = order + 1;
-                        draftTimingsEntry.pick = i < 12 ? false : true;
+                        draftTimingsEntry.pick = i >= 14;
                         draftTimingsEntry.hero_id = draftHeroes[i];
                         draftTimingsEntry.draft_active_team = getEntityProperty(grp, "m_pGameRules.m_iActiveTeam", null);
                         draftTimingsEntry.draft_extime0 = Math.round((float) getEntityProperty(grp, "m_pGameRules.m_fExtraTimeRemaining.0000", null));


### PR DESCRIPTION
The parser was missing the 2 extra hero bans added in 7.27.

I've tested this with these match IDs:
TI8 finals game 1: 4080601137
Singapore major game 1: 5926402991
TI10 groups VP v Aster game 1: 6216583629, which produces:
```json
  "draft_timings": [
    ...
    {
      "order": 19,
      "pick": false,
      "active_team": 2,
      "hero_id": 4,
      "player_slot": null,
      "extra_time": 130,
      "total_time_taken": 46
    },
    {
      "order": 20,
      "pick": false,
      "active_team": 3,
      "hero_id": 36,
      "player_slot": null,
      "extra_time": 56,
      "total_time_taken": 18
    },
    {
      "order": 21,
      "pick": false,
      "active_team": 2,
      "hero_id": 77,
      "player_slot": null,
      "extra_time": 130,
      "total_time_taken": 28
    },
    {
      "order": 22,
      "pick": false,
      "active_team": 3,
      "hero_id": 94,
      "player_slot": null,
      "extra_time": 56,
      "total_time_taken": 38
    },
    {
      "order": 23,
      "pick": true,
      "active_team": 2,
      "hero_id": 95,
      "player_slot": 0,
      "extra_time": 121,
      "total_time_taken": 19
    },
    {
      "order": 24,
      "pick": true,
      "active_team": 3,
      "hero_id": 108,
      "player_slot": 7,
      "extra_time": 20,
      "total_time_taken": 132
    }
  ]
```
after the changes.

Before:
```json
"draft_timings": [
    ...
    {
      "order": 18,
      "pick": true,
      "active_team": 3,
      "hero_id": 3,
      "player_slot": 8,
      "extra_time": 73,
      "total_time_taken": 18
    },
    {
      "order": 19,
      "pick": false,
      "active_team": 2,
      "hero_id": 4,
      "player_slot": null,
      "extra_time": 130,
      "total_time_taken": 46
    },
    {
      "order": 20,
      "pick": false,
      "active_team": 3,
      "hero_id": 77,
      "player_slot": null,
      "extra_time": 130,
      "total_time_taken": 46
    },
    {
      "order": 21,
      "pick": true,
      "active_team": 3,
      "hero_id": 95,
      "player_slot": 0,
      "extra_time": 121,
      "total_time_taken": 57
    },
    {
      "order": 22,
      "pick": true,
      "active_team": 3,
      "hero_id": 108,
      "player_slot": 7,
      "extra_time": 20,
      "total_time_taken": 132
    }
  ],
```
(json taken from odota/core `GET /api/matches/:match_id` output)