### PR TITLE
Fix wards

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -258,7 +258,6 @@ public class Parse {
         // Try pre 7.31 method
         Integer slot = getEntityProperty(e, "m_iPlayerID", null);
         if (slot != null) {
-            System.out.println("Successful m_iPlayerID: " + slot);
             return slot;
         }
         String heroName = null;

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -253,14 +253,21 @@ public class Parse {
         //System.err.println(message);
     }
 
-    public int getPlayerSlotFromEntity(Context ctx, Entity e) {
+    public Integer getPlayerSlotFromEntity(Context ctx, Entity e) {
+        if (e == null) return null;
+        // Try pre 7.31 method
+        Integer slot = getEntityProperty(e, "m_iPlayerID", null);
+        if (slot != null) {
+            System.out.println("Successful m_iPlayerID: " + slot);
+            return slot;
+        }
         String heroName = null;
         Entity heroEnt = ctx.getProcessor(Entities.class).getByHandle(e.getProperty("m_hAssignedHero"));
         if (heroEnt != null) {
             heroName = heroEnt.getDtClass().getDtName();
             return (unit_to_slot.get(heroName) == null) ? -1 : unit_to_slot.get(heroName);
         }
-        return -1;
+        return null;
     }
 
     @OnMessage(CDOTAUserMsg_SpectatorPlayerUnitOrders.class)

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -913,8 +913,8 @@ public class Parse {
         }
         
         Integer owner = getEntityProperty(e, "m_hOwnerEntity", null); 
-        Entity ownerEntity = ctx.getProcessor(Entities.class).getByHandle(owner); 
-        entry.slot = ownerEntity != null ? (Integer) getEntityProperty(ownerEntity, "m_iPlayerID", null) : null; 
+        Entity ownerEntity = ctx.getProcessor(Entities.class).getByHandle(owner);
+        entry.slot = getPlayerSlotFromEntity(ctx, ownerEntity);
         
         return entry; 
     }

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -264,7 +264,7 @@ public class Parse {
         Entity heroEnt = ctx.getProcessor(Entities.class).getByHandle(e.getProperty("m_hAssignedHero"));
         if (heroEnt != null) {
             heroName = heroEnt.getDtClass().getDtName();
-            return (unit_to_slot.get(heroName) == null) ? -1 : unit_to_slot.get(heroName);
+            return unit_to_slot.get(heroName);
         }
         return null;
     }


### PR DESCRIPTION
Fixes https://github.com/odota/web/issues/2923

Changes to `getPlayerSlotFromEntity`:
* added entity null check
* attempts to use `m_iPlayerID` for backward compatibility 
* Now returns null instead of -1 on failure

Related to https://github.com/odota/parser/pull/55