### PR TITLE
Fix to build on MacOS M1 locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-openjdk-8
+FROM maven:3.8.3-openjdk-8
 
 WORKDIR /usr/src/parser
 ADD . /usr/src/parser

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-sudo docker build -t odota/parser .
+# To build on M1 MacOS specify the platform argument
+# For example: sh scripts/rebuild.sh --platform linux/arm64/v8
+sudo docker build -t odota/parser $1 .
 sudo docker rm -fv parser
-sudo docker run -d --name parser --net=host odota/parser
+sudo docker run -d --name parser -p 5600:5600 odota/parser


### PR DESCRIPTION
- Bumped maven's version
- The rebuild script now can use command-line arguments like
`sh scripts/rebuild.sh --platform linux/arm64/v8`
