### PR TITLE
Fix cosmetics

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -466,13 +466,10 @@ public class Parse {
         if (e.getDtClass().getDtName().equals("CDOTAWearableItem")) {
         	Integer accountId = getEntityProperty(e, "m_iAccountID", null);
         	Integer itemDefinitionIndex = getEntityProperty(e, "m_iItemDefinitionIndex", null);
-        	Integer ownerHandle = getEntityProperty(e, "m_hOwnerEntity", null);
-            Entity owner = ownerHandle != null ? ctx.getProcessor(Entities.class).getByHandle(ownerHandle) : null;
         	//System.err.format("%s,%s\n", accountId, itemDefinitionIndex);
-        	if (accountId > 0 && owner != null)
+        	if (accountId > 0)
         	{
             	// Get the owner (a hero entity)
-            	Integer playerId = getEntityProperty(owner, "m_iPlayerID", null);
         	    Long accountId64 = 76561197960265728L + accountId;
         	    Integer playerSlot = steamid_to_playerslot.get(accountId64);
         		cosmeticsMap.put(itemDefinitionIndex, playerSlot);


### PR DESCRIPTION
It seems that there no longer is an `m_hOwnerEntity` property on `CDOTAWearableItem`, so I removed the check. Not sure what it was for in the first place - didn't see any strangeness in my testing without it.