### PR TITLE
extract precise locations from replay parse

### DIFF
--- a/processors/processExpand.mjs
+++ b/processors/processExpand.mjs
@@ -594,6 +594,7 @@ function processExpand(entries, meta) {
           time: e.time,
           slot: e.slot,
           type: 'lane_pos',
+          key: JSON.stringify([e.x,e.y].map(n => parseFloat(n.toFixed(1)))),
           posData: true,
         });
       }

--- a/processors/processExpand.mjs
+++ b/processors/processExpand.mjs
@@ -26,6 +26,12 @@ function processExpand(entries, meta) {
    * Place a copy of the entry in the output
    * */
   function expand(e) {
+    //if there are cooridnates, round to one decimal point
+    e.x?e.x=parseFloat(e.x.toFixed(1)):null
+    e.y?e.y=parseFloat(e.y.toFixed(1)):null
+    e.z?e.z=parseFloat(e.z.toFixed(1)):null
+    //generate "key" for entries with x/y and no key
+    if (!e.key && e.x && e.y) e.key = JSON.stringify([e.x,e.y])
     // set slot and player_slot
     const slot = 'slot' in e ? e.slot : meta.hero_to_slot[e.unit];
     output.push({ ...e, slot, player_slot: meta.slot_to_playerslot[slot] });
@@ -588,7 +594,6 @@ function processExpand(entries, meta) {
           time: e.time,
           slot: e.slot,
           type: 'lane_pos',
-          key: JSON.stringify([e.x, e.y]),
           posData: true,
         });
       }

--- a/processors/processExpand.mjs
+++ b/processors/processExpand.mjs
@@ -27,11 +27,17 @@ function processExpand(entries, meta) {
    * */
   function expand(e) {
     //if there are cooridnates, round to one decimal point
-    e.x?e.x=parseFloat(e.x.toFixed(1)):null
-    e.y?e.y=parseFloat(e.y.toFixed(1)):null
-    e.z?e.z=parseFloat(e.z.toFixed(1)):null
+    if (e.x) { e.x=parseFloat(e.x.toFixed(1)) }
+    if (e.y) { e.y=parseFloat(e.y.toFixed(1)) }
+    if (e.z) { e.z=parseFloat(e.z.toFixed(1)) }
     //generate "key" for entries with x/y and no key
-    if (!e.key && e.x && e.y) e.key = JSON.stringify([e.x,e.y])
+    if (!e.key && e.x && e.y) { 
+      const key = [
+        Math.round(e.x),
+        Math.round(e.y)
+      ]
+      e.key = JSON.stringify(key) 
+    }
     // set slot and player_slot
     const slot = 'slot' in e ? e.slot : meta.hero_to_slot[e.unit];
     output.push({ ...e, slot, player_slot: meta.slot_to_playerslot[slot] });
@@ -594,7 +600,10 @@ function processExpand(entries, meta) {
           time: e.time,
           slot: e.slot,
           type: 'lane_pos',
-          key: JSON.stringify([e.x,e.y].map(n => parseFloat(n.toFixed(1)))),
+          key: JSON.stringify([
+            Math.round(e.x),
+            Math.round(e.y)
+          ]),
           posData: true,
         });
       }

--- a/processors/processExpand.mjs
+++ b/processors/processExpand.mjs
@@ -32,11 +32,10 @@ function processExpand(entries, meta) {
     if (e.z) { e.z=parseFloat(e.z.toFixed(1)) }
     //generate "key" for entries with x/y and no key
     if (!e.key && e.x && e.y) { 
-      const key = [
+      e.key = JSON.stringify([
         Math.round(e.x),
         Math.round(e.y)
-      ]
-      e.key = JSON.stringify(key) 
+      ]) 
     }
     // set slot and player_slot
     const slot = 'slot' in e ? e.slot : meta.hero_to_slot[e.unit];

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -77,9 +77,9 @@ public class Parse {
         public Integer gold;
         public Integer lh;
         public Integer xp;
-        public Integer x;
-        public Integer y;
-        public Integer z;
+        public Float x;
+        public Float y;
+        public Float z;
         public Float stuns;
         public Integer hero_id;
         public transient List<Item> hero_inventory;
@@ -126,6 +126,10 @@ public class Parse {
         public Entry(Integer time) {
             this.time = time;
         }
+    }
+
+    private Float getPreciseLocation (Integer cell, Float vec) {
+      return (cell*128.0f+vec)/128;
     }
 
     private class Item {
@@ -724,8 +728,15 @@ public class Parse {
                     // get the hero's coordinates
                     if (e != null) {
                         // System.err.println(e);
-                        entry.x = getEntityProperty(e, "CBodyComponent.m_cellX", null);
-                        entry.y = getEntityProperty(e, "CBodyComponent.m_cellY", null);
+                        //CBodyComponent.m_cell[XY] * 128 + CBodyComponent.m_vec[XY]
+                        Integer cx = getEntityProperty(e, "CBodyComponent.m_cellX", null);
+                        Integer cy = getEntityProperty(e, "CBodyComponent.m_cellY", null);
+
+                        Float vx = getEntityProperty(e, "CBodyComponent.m_vecX", null);
+                        Float vy = getEntityProperty(e, "CBodyComponent.m_vecY", null);
+
+                        entry.x = getPreciseLocation(cx,vx);
+                        entry.y = getPreciseLocation(cy,vy);
                         // System.err.format("%s, %s\n", entry.x, entry.y);
                         // get the hero's entity name, ex: CDOTA_Hero_Zuus
                         entry.unit = e.getDtClass().getDtName();
@@ -955,14 +966,26 @@ public class Parse {
     private Entry buildWardEntry(Context ctx, Entity e) {
         Entry entry = new Entry(time);
         boolean isObserver = !e.getDtClass().getDtName().contains("TrueSight");
-        Integer x = getEntityProperty(e, "CBodyComponent.m_cellX", null);
-        Integer y = getEntityProperty(e, "CBodyComponent.m_cellY", null);
-        Integer z = getEntityProperty(e, "CBodyComponent.m_cellZ", null);
+
+        Integer cx = getEntityProperty(e, "CBodyComponent.m_cellX", null);
+        Integer cy = getEntityProperty(e, "CBodyComponent.m_cellY", null);
+        Integer cz = getEntityProperty(e, "CBodyComponent.m_cellZ", null);
+
+        Float vx = getEntityProperty(e, "CBodyComponent.m_vecX", null);
+        Float vy = getEntityProperty(e, "CBodyComponent.m_vecY", null);
+        Float vz = getEntityProperty(e, "CBodyComponent.m_vecZ", null);
+
+        Float x = getPreciseLocation(cx,vx);
+        Float y = getPreciseLocation(cy,vy);
+        Float z = getPreciseLocation(cz,vz);
+
         Integer life_state = getEntityProperty(e, "m_lifeState", null);
-        Integer[] pos = { x, y };
+        Float[] pos = { x, y };
+
         entry.x = x;
         entry.y = y;
         entry.z = z;
+
         entry.type = isObserver ? "obs" : "sen";
         entry.entityleft = life_state == 1;
         entry.key = Arrays.toString(pos);

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -975,20 +975,14 @@ public class Parse {
         Float vy = getEntityProperty(e, "CBodyComponent.m_vecY", null);
         Float vz = getEntityProperty(e, "CBodyComponent.m_vecZ", null);
 
-        Float x = getPreciseLocation(cx,vx);
-        Float y = getPreciseLocation(cy,vy);
-        Float z = getPreciseLocation(cz,vz);
-
         Integer life_state = getEntityProperty(e, "m_lifeState", null);
-        Float[] pos = { x, y };
 
-        entry.x = x;
-        entry.y = y;
-        entry.z = z;
+        entry.x = getPreciseLocation(cx,vx);
+        entry.y = getPreciseLocation(cy,vy);
+        entry.z = getPreciseLocation(cz,vz);
 
         entry.type = isObserver ? "obs" : "sen";
         entry.entityleft = life_state == 1;
-        entry.key = Arrays.toString(pos);
         entry.ehandle = e.getHandle();
 
         if (entry.entityleft) {


### PR DESCRIPTION
when parsing ward/hero locations, add m_vec to m_cell location to get precise location, convert locations to floats rather than ints

see [here](https://github.com/skadistats/clarity-examples/blob/ab1029bdf72d3e7aeb27f98e2f0745909014bd7e/src/main/java/skadistats/clarity/examples/position/Main.java#L173) for a reference as to how this is calculated

the resultant data should broadly be compatible with previous APIs expecting ints (assuming JS `parseInt` or `JSON.parse` , I haven't actually read through the code that consumes this and this could be a breaking change, and things expecting ints should round rather than truncate, but generally i would expect everything to be fine)

this update fixes some ward placement accuracy bugs, see the following [match on odota](https://www.opendota.com/matches/7740976363/vision), at around 10 minutes there is a ward battle around the bot lane plateau and the ward locations in the UI are shown like this
![image](https://github.com/odota/parser/assets/94414189/f786adcb-4be6-4316-807b-9f0d0b3c16d7)
however as we can see in the client, the locations aren't nearly as far apart
![image](https://github.com/odota/parser/assets/94414189/af7088d0-2a84-4e35-bb8e-fb41ea1cd1be)

specifically, the old cell-only interpretations reports the obs ward as 200 in game units apart
```js
{
  "time": 677,
  "type": "sen",
  "slot": 8,
  "x": 158,
  "y": 92,
  "z": 132,
  ...
}
{
  "time": 679,
  "type": "obs",
  "slot": 8,
  "x": 158,
  "y": 90, // the obs is reported as 2 cells, i.e. 200 in game units lower
  "z": 132,
  ...
}
```
whereas the pull-request implementation shows the true locations much closer together  (~20 units apart) as per the screenshot
```js
{
  "time": 677,
  "type": "sen",
  "x": 158.2976,
  "y": 92.05322,
  "z": 132.1875,
  ...
}
{
  "time": 679,
  "type": "obs",
  "x": 158.27075,
  "y": 91.83862,
  "z": 132.1875,
  ...
}
```
