### PR TITLE
feat: add neutral token drops data

### DIFF
--- a/processors/parseSchema.mjs
+++ b/processors/parseSchema.mjs
@@ -66,5 +66,6 @@ export default {
     randomed: false,
     repicked: false,
     pred_vict: false,
+    neutral_token: [],
   })),
 };

--- a/processors/parseSchema.mjs
+++ b/processors/parseSchema.mjs
@@ -66,6 +66,6 @@ export default {
     randomed: false,
     repicked: false,
     pred_vict: false,
-    neutral_token: [],
+    neutral_tokens_log: [],
   })),
 };

--- a/processors/populate.mjs
+++ b/processors/populate.mjs
@@ -66,7 +66,8 @@ function populate(e, container, meta) {
         } else if (
           e.type === 'purchase_log' ||
           e.type === 'kills_log' ||
-          e.type === 'runes_log'
+          e.type === 'runes_log' ||
+          e.type === 'neutral_tokens_log'
         ) {
           arrEntry = {
             time: e.time,

--- a/processors/processExpand.mjs
+++ b/processors/processExpand.mjs
@@ -630,6 +630,9 @@ function processExpand(entries, meta) {
     cosmetics(e) {
       expand(e);
     },
+    neutral_token(e) {
+      expand(e);
+    },
   };
   for (let i = 0; i < entries.length; i += 1) {
     const e = entries[i];

--- a/processors/processExpand.mjs
+++ b/processors/processExpand.mjs
@@ -631,7 +631,10 @@ function processExpand(entries, meta) {
       expand(e);
     },
     neutral_token(e) {
-      expand(e);
+      expand({
+        ...e,
+        type: 'neutral_tokens_log',
+      });
     },
   };
   for (let i = 0; i < entries.length; i += 1) {

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -275,6 +275,9 @@ public class Parse {
         if (slot == null) {
             slot = getEntityProperty(e, "m_iPlayerID", null);
         }
+        if (slot == null) {
+            slot = getEntityProperty(e, "m_iPlayerOwnerID", null);
+        }
         if (slot != null) {
             slot /= 2;
         }
@@ -473,7 +476,9 @@ public class Parse {
 
     @OnEntityEntered
     public void onEntityEntered(Context ctx, Entity e) {
-        if (e.getDtClass().getDtName().equals("CDOTAWearableItem")) {
+        String entityName = e.getDtClass().getDtName();
+
+        if (entityName.equals("CDOTAWearableItem")) {
             Integer accountId = getEntityProperty(e, "m_iAccountID", null);
             Integer itemDefinitionIndex = getEntityProperty(e, "m_iItemDefinitionIndex", null);
             // System.err.format("%s,%s\n", accountId, itemDefinitionIndex);
@@ -483,6 +488,12 @@ public class Parse {
                 Integer playerSlot = steamid_to_playerslot.get(accountId64);
                 cosmeticsMap.put(itemDefinitionIndex, playerSlot);
             }
+        } else if (entityName.startsWith("CDOTA_Item_Tier") && entityName.endsWith("Token")) {
+            Entry entry = new Entry(time);
+            entry.type = "neutral_token";
+            entry.slot = getPlayerSlotFromEntity(ctx, e);
+            entry.key = entityName.substring("CDOTA_Item_".length()); // Tier1Token
+            output(entry);
         }
     }
 


### PR DESCRIPTION
### Description
This small PR adds the ability to track the neutral tokens drops

### Output changes
After Java processing, new lines will be added to the output in the following format:
```json
{"time":434,"type":"neutralToken","key":"Tier1Token","slot":0}
```

After Node.js processing, a new field `neutral_token` will be added to the player object, which will look like this:
```json
{
  // ...
  "players": [
    {
      // ...
      "neutral_tokens_log": [
        {
          "time": 1628,
          "key": "Tier3Token"
        },
        {
          "time": 2299,
          "key": "Tier4Token"
        }
      ]
    }
    // ...
  ]
}
```
