### PR TITLE
Neutral items history

### DIFF
--- a/processors/parseSchema.mjs
+++ b/processors/parseSchema.mjs
@@ -67,5 +67,6 @@ export default {
     repicked: false,
     pred_vict: false,
     neutral_tokens_log: [],
+    neutral_item_history: []
   })),
 };

--- a/processors/populate.mjs
+++ b/processors/populate.mjs
@@ -72,7 +72,7 @@ function populate(e, container, meta) {
             time: e.time,
           }
           arrEntry.item_neutral = e.isNeutralActiveDrop ? itemName : (arrEntry.item_neutral ?? null)
-          arrEntry.item_neutral_enchant = e.isNeutralPassiveDrop ? itemName : (arrEntry.item_neutral_enchant ?? null)
+          arrEntry.item_neutral_enhancement = e.isNeutralPassiveDrop ? itemName : (arrEntry.item_neutral_enhancement ?? null)
           if (existedEl) {
             existedEl = arrEntry
           } else {

--- a/processors/processExpand.mjs
+++ b/processors/processExpand.mjs
@@ -640,6 +640,9 @@ function processExpand(entries, meta) {
         type: 'neutral_tokens_log',
       });
     },
+    neutral_item_history(e) {
+      expand(e)
+    },
   };
   for (let i = 0; i < entries.length; i += 1) {
     const e = entries[i];

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -95,6 +95,8 @@ public class Parse {
         public Integer denies;
         public Boolean entityleft;
         public Integer ehandle;
+        public Boolean isNeutralActiveDrop;
+        public Boolean isNeutralPassiveDrop;
         public Integer obs_placed;
         public Integer sen_placed;
         public Integer creeps_stacked;
@@ -494,6 +496,19 @@ public class Parse {
             entry.slot = getPlayerSlotFromEntity(ctx, e);
             entry.key = entityName.substring("CDOTA_Item_".length()); // Tier1Token
             output(entry);
+        } else if (entityName.startsWith("CDOTA_Item_")) {
+            Boolean isNeutralActiveDrop = getEntityProperty(e, "m_bIsNeutralActiveDrop", null);
+            Boolean isNeutralPassiveDrop = getEntityProperty(e, "m_bIsNeutralPassiveDrop", null);
+            if ((isNeutralActiveDrop != null && isNeutralActiveDrop) || (isNeutralPassiveDrop != null && isNeutralPassiveDrop == true)) {
+                Entry entry = new Entry(time);
+                entry.type = "neutral_item_history";
+                entry.slot = getPlayerSlotFromEntity(ctx, e);
+                entry.key = entityName.substring("CDOTA_Item_".length());
+                entry.isNeutralActiveDrop = isNeutralActiveDrop;
+                entry.isNeutralPassiveDrop = isNeutralPassiveDrop;
+                // System.out.println(new Gson().toJson(entry));
+                output(entry);
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Small PR to add neutral item history with neutral item enhancements. 

### Output Changes
After Java processing, new lines will be added in following format
`{"time":568,"type":"neutral_item_history","key":"Mana_Draught","slot":0,isNeutralActiveDrop: true,isNeutralPassiveDrop: false}`

After Node.js processing, new field neutral_item_history will be added to player object, that looks like:
```json
"neutral_item_history": [
        {
          "time": 532,
          "item_neutral": "polliwog_charm",
          "item_neutral_enhancement": "enhancement_quickened"
        },
        {
          "time": 1159,
          "item_neutral": "searing_signet",
          "item_neutral_enhancement": "enhancement_brawny"
        },
        {
          "time": 1701,
          "item_neutral": "gale_guard",
          "item_neutral_enhancement": "enhancement_vampiric"
        },
        {
          "time": 2179,
          "item_neutral": "crippling_crossbow",
          "item_neutral_enhancement": "enhancement_brawny"
        }
      ]
```

May be, you already had some method to convert Valve's mixed CamelCase with Snake_Case in item names to snake_case and this code could be better
```js
let itemName = e.key.replace(/([A-Z])/g, ($1) => `_${$1.toLowerCase()}`).toLowerCase().replace('__', '_')
if (itemName.startsWith('_')) {
  itemName = itemName.replace(/^_/g, '')
}
```