### PR TITLE
double __ fix in neutral item history

### DIFF
--- a/processors/populate.mjs
+++ b/processors/populate.mjs
@@ -63,7 +63,7 @@ function populate(e, container, meta) {
         let arrEntry;
 
         if (e.type==='neutral_item_history') {
-          let itemName = e.key.replace(/([A-Z])/g, ($1) => `_${$1.toLowerCase()}`).toLowerCase().replace('__', '_')
+          let itemName = e.key.replace(/([A-Z])/g, ($1) => `_${$1.toLowerCase()}`).toLowerCase().replaceAll('__', '_')
           if (itemName.startsWith('_')) {
             itemName = itemName.replace(/^_/g, '')
           }


### PR DESCRIPTION
Fixes bug with neutral items that have more than 2 word. Previously during converting only first `__` was replaced with `_`
I'm terribly sorry for such a stupid mistake of mine