### PR TITLE
quickfix to make ability level events work after 7.38

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -884,7 +884,6 @@ public class Parse {
                 Ability ability = getHeroAbilities(ctx, eHero, i);
                 if (ability != null) {
                     abilityList.add(ability);
-
                 }
             } catch (Exception e) {
                 // System.err.println(e);
@@ -946,10 +945,19 @@ public class Parse {
         StringTable stEntityNames = ctx.getProcessor(StringTables.class).forName("EntityNames");
         Entities entities = ctx.getProcessor(Entities.class);
 
-        Integer hAbility = eHero.getProperty("m_hAbilities." + Util.arrayIdxToString(idx));
+        Integer hAbility;
+        if (eHero.hasProperty("m_hAbilities." + Util.arrayIdxToString(idx))) {
+            hAbility = eHero.getProperty("m_hAbilities." + Util.arrayIdxToString(idx));
+        } else if (eHero.hasProperty("m_vecAbilities." + Util.arrayIdxToString(idx))) {
+            hAbility = eHero.getProperty("m_vecAbilities." + Util.arrayIdxToString(idx));
+        } else {
+            hAbility = 0xFFFFFF;
+        }
+        
         if (hAbility == 0xFFFFFF) {
             return null;
         }
+        
         Entity eAbility = entities.getByHandle(hAbility);
         if (eAbility == null) {
             throw new UnknownAbilityFoundException(String.format("Can't find ability by its handle (%d)", hAbility));
@@ -975,6 +983,9 @@ public class Parse {
                 property = property.replace("%i", Util.arrayIdxToString(idx));
             }
             FieldPath fp = e.getDtClass().getFieldPathForName(property);
+            if (fp == null) {
+                return null;
+            }
             return e.getPropertyForFieldPath(fp);
         } catch (Exception ex) {
             return null;


### PR DESCRIPTION
in 7.38 the key for ability entities was changed from m_hAbilities to m_vecAbilities (and a dynamic number of elements, as `vec` suggests). Because of this `getHeroAbilities` was failing with an exception, returning nothing. This also affected track/greevils greed processors, I believe.

Added `hasProperty` checks to decide which key to use to get the property (for compatibility with pre-7.38 replays) and whether the element even exists.

This might be a bit redundant, as `getProperty` effectively does the same check (just throws exception on null), but this reads better.