### PR TITLE
Bug fix that new illusion creates new neutral item instance

### DIFF
--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -499,7 +499,8 @@ public class Parse {
         } else if (entityName.startsWith("CDOTA_Item_")) {
             Boolean isNeutralActiveDrop = getEntityProperty(e, "m_bIsNeutralActiveDrop", null);
             Boolean isNeutralPassiveDrop = getEntityProperty(e, "m_bIsNeutralPassiveDrop", null);
-            if ((isNeutralActiveDrop != null && isNeutralActiveDrop) || (isNeutralPassiveDrop != null && isNeutralPassiveDrop == true)) {
+            Integer neutralDropTeam = getEntityProperty(e, "m_nNeutralDropTeam", null);
+            if ((neutralDropTeam != null && neutralDropTeam != 0) && ((isNeutralActiveDrop != null && isNeutralActiveDrop) || (isNeutralPassiveDrop != null && isNeutralPassiveDrop == true))) {
                 Entry entry = new Entry(time);
                 entry.type = "neutral_item_history";
                 entry.slot = getPlayerSlotFromEntity(ctx, e);


### PR DESCRIPTION
This PR fixes bug that every time player with neutral item creates illusion (same with Arc Warden illusion; Lone Druid and Meepo was not affected because their summon/clones can't use neutral slot) - new neutral item instance was created. In result, illusionists had 100+ neutral items in history

P.S. Is it possible to force re-parse matches that was affected by this bug? It seems like button/api route to request match to be parsed does not work if match was already parsed. If it's not possible to do automatically - I can provide new data from replay parser for all 7.38 matches, so you don't have to re-parse almost 1k matches at server