### PR TITLE
Bump clarity to 4.0.1 and cache FieldPath lookups (~18% faster)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.skadistats</groupId>
             <artifactId>clarity</artifactId>
-            <version>3.1.3</version>
+            <version>4.0.1</version>
         </dependency>
 
         <dependency>
@@ -77,18 +77,13 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>opendota.Main</mainClass>
                                 </transformer>
-                                <transformer implementation="org.atteo.classindex.ClassIndexTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/clarity/providers.txt</resource>
+                                </transformer>
                             </transformers>
                         </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.atteo.classindex</groupId>
-                        <artifactId>classindex-transformer</artifactId>
-                        <version>3.4</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -3,6 +3,7 @@ package opendota;
 import com.google.gson.Gson;
 import com.google.protobuf.GeneratedMessage;
 import skadistats.clarity.io.Util;
+import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.Entity;
 import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.StringTable;
@@ -941,6 +942,9 @@ public class Parse {
         return idx;
     }
 
+    private final Object fpAbsent = new Object();
+    private final IdentityHashMap<DTClass, HashMap<String, Object>> fpCache = new IdentityHashMap<>();
+
     public <T> T getEntityProperty(Entity e, String property, Integer idx) {
         try {
             if (e == null) {
@@ -949,11 +953,22 @@ public class Parse {
             if (idx != null) {
                 property = property.replace("%i", Util.arrayIdxToString(idx));
             }
-            FieldPath fp = e.getDtClass().getFieldPathForName(property);
-            if (fp == null) {
+            DTClass dt = e.getDtClass();
+            HashMap<String, Object> perClass = fpCache.get(dt);
+            if (perClass == null) {
+                perClass = new HashMap<>();
+                fpCache.put(dt, perClass);
+            }
+            Object cached = perClass.get(property);
+            if (cached == null) {
+                FieldPath resolved = dt.getFieldPathForName(property);
+                cached = resolved == null ? fpAbsent : resolved;
+                perClass.put(property, cached);
+            }
+            if (cached == fpAbsent) {
                 return null;
             }
-            return e.getPropertyForFieldPath(fp);
+            return e.getPropertyForFieldPath((FieldPath) cached);
         } catch (Exception ex) {
             return null;
         }

--- a/src/main/java/opendota/Parse.java
+++ b/src/main/java/opendota/Parse.java
@@ -26,7 +26,7 @@ import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages.CDOTAUserMsg_C
 import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages.CDOTAUserMsg_ChatWheel;
 import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages.CDOTAUserMsg_LocationPing;
 import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages.CDOTAUserMsg_SpectatorPlayerUnitOrders;
-import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages.DOTA_COMBATLOG_TYPES;
+import skadistats.clarity.wire.dota.common.proto.DOTACombatLog.DOTA_COMBATLOG_TYPES;
 import skadistats.clarity.wire.dota.s2.proto.DOTAS2GcMessagesCommon.CMsgDOTAMatch;
 import skadistats.clarity.wire.shared.s1.proto.S1UserMessages.CUserMsg_SayText2;
 import skadistats.clarity.wire.shared.s2.proto.S2UserMessages.CUserMessageSayText2;

--- a/src/main/java/opendota/combatlogvisitors/GreevilsGreedVisitor.java
+++ b/src/main/java/opendota/combatlogvisitors/GreevilsGreedVisitor.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import skadistats.clarity.model.CombatLogEntry;
-import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages.DOTA_COMBATLOG_TYPES;
+import skadistats.clarity.wire.dota.common.proto.DOTACombatLog.DOTA_COMBATLOG_TYPES;
 
 public class GreevilsGreedVisitor implements Visitor<Integer> {
 

--- a/src/main/java/opendota/combatlogvisitors/TrackVisitor.java
+++ b/src/main/java/opendota/combatlogvisitors/TrackVisitor.java
@@ -3,7 +3,7 @@ package opendota.combatlogvisitors;
 import java.util.HashMap;
 
 import skadistats.clarity.model.CombatLogEntry;
-import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages.DOTA_COMBATLOG_TYPES;
+import skadistats.clarity.wire.dota.common.proto.DOTACombatLog.DOTA_COMBATLOG_TYPES;
 
 public class TrackVisitor implements Visitor<TrackVisitor.TrackStatus> {
 

--- a/src/main/java/opendota/processors/warding/OnWardExpired.java
+++ b/src/main/java/opendota/processors/warding/OnWardExpired.java
@@ -1,5 +1,7 @@
 package opendota.processors.warding;
 
+import skadistats.clarity.event.EventBase;
+import skadistats.clarity.event.GenerateEvent;
 import skadistats.clarity.event.UsagePointMarker;
 import skadistats.clarity.event.UsagePointType;
 import skadistats.clarity.model.Entity;
@@ -11,7 +13,14 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = ElementType.METHOD)
-@UsagePointMarker(value = UsagePointType.EVENT_LISTENER, parameterClasses = { Entity.class })
-public @interface OnWardExpired { 
-}
+@UsagePointMarker(value = UsagePointType.EVENT_LISTENER)
+@GenerateEvent
+public @interface OnWardExpired {
+    interface Listener {
+        void invoke(Entity e);
+    }
 
+    interface Event extends EventBase {
+        void raise(Entity e);
+    }
+}

--- a/src/main/java/opendota/processors/warding/OnWardKilled.java
+++ b/src/main/java/opendota/processors/warding/OnWardKilled.java
@@ -1,5 +1,7 @@
 package opendota.processors.warding;
 
+import skadistats.clarity.event.EventBase;
+import skadistats.clarity.event.GenerateEvent;
 import skadistats.clarity.event.UsagePointMarker;
 import skadistats.clarity.event.UsagePointType;
 import skadistats.clarity.model.Entity;
@@ -11,7 +13,14 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = ElementType.METHOD)
-@UsagePointMarker(value = UsagePointType.EVENT_LISTENER, parameterClasses = { Entity.class, String.class })
-public @interface OnWardKilled { 
-}
+@UsagePointMarker(value = UsagePointType.EVENT_LISTENER)
+@GenerateEvent
+public @interface OnWardKilled {
+    interface Listener {
+        void invoke(Entity e, String killerHeroName);
+    }
 
+    interface Event extends EventBase {
+        void raise(Entity e, String killerHeroName);
+    }
+}

--- a/src/main/java/opendota/processors/warding/OnWardPlaced.java
+++ b/src/main/java/opendota/processors/warding/OnWardPlaced.java
@@ -1,5 +1,7 @@
 package opendota.processors.warding;
 
+import skadistats.clarity.event.EventBase;
+import skadistats.clarity.event.GenerateEvent;
 import skadistats.clarity.event.UsagePointMarker;
 import skadistats.clarity.event.UsagePointType;
 import skadistats.clarity.model.Entity;
@@ -11,7 +13,14 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = ElementType.METHOD)
-@UsagePointMarker(value = UsagePointType.EVENT_LISTENER, parameterClasses = { Entity.class })
-public @interface OnWardPlaced { 
-}
+@UsagePointMarker(value = UsagePointType.EVENT_LISTENER)
+@GenerateEvent
+public @interface OnWardPlaced {
+    interface Listener {
+        void invoke(Entity e);
+    }
 
+    interface Event extends EventBase {
+        void raise(Entity e);
+    }
+}

--- a/src/main/java/opendota/processors/warding/Wards.java
+++ b/src/main/java/opendota/processors/warding/Wards.java
@@ -22,7 +22,7 @@ import skadistats.clarity.processor.entities.UsesEntities;
 import skadistats.clarity.processor.gameevents.OnCombatLogEntry;
 import skadistats.clarity.processor.reader.OnTickEnd;
 import skadistats.clarity.processor.runner.Context;
-import skadistats.clarity.wire.dota.common.proto.DOTAUserMessages;
+import skadistats.clarity.wire.dota.common.proto.DOTACombatLog;
 
 /**
  * @author micaelbergeron
@@ -56,9 +56,9 @@ public class Wards {
     private final Map<String, Queue<String>> wardKillersByWardClass = new HashMap<>();
     private Queue<ProcessEntityCommand> toProcess = new ArrayDeque<>();
 
-    private Event<OnWardKilled> evKilled;
-    private Event<OnWardExpired> evExpired;
-    private Event<OnWardPlaced> evPlaced;
+    private OnWardKilled.Event evKilled;
+    private OnWardExpired.Event evExpired;
+    private OnWardPlaced.Event evPlaced;
     
     private class ProcessEntityCommand {
 
@@ -73,17 +73,17 @@ public class Wards {
 
     @Initializer(OnWardKilled.class)
     public void initOnWardKilled(final Context ctx, final EventListener<OnWardKilled> listener) {
-        evKilled = ctx.createEvent(OnWardKilled.class, Entity.class, String.class);
+        evKilled = (OnWardKilled.Event) ctx.createEvent(OnWardKilled.class);
     }
-    
+
     @Initializer(OnWardExpired.class)
     public void initOnWardExpired(final Context ctx, final EventListener<OnWardExpired> listener) {
-        evExpired = ctx.createEvent(OnWardExpired.class, Entity.class);
+        evExpired = (OnWardExpired.Event) ctx.createEvent(OnWardExpired.class);
     }
-        
+
     @Initializer(OnWardPlaced.class)
     public void initOnWardPlaced(final Context ctx, final EventListener<OnWardPlaced> listener) {
-        evPlaced = ctx.createEvent(OnWardPlaced.class, Entity.class);
+        evPlaced = (OnWardPlaced.Event) ctx.createEvent(OnWardPlaced.class);
     }
 
     public Wards() {
@@ -163,7 +163,7 @@ public class Wards {
     }
     
     private boolean isWardDeath(CombatLogEntry e) {
-        return e.getType().equals(DOTAUserMessages.DOTA_COMBATLOG_TYPES.DOTA_COMBATLOG_DEATH)
+        return e.getType().equals(DOTACombatLog.DOTA_COMBATLOG_TYPES.DOTA_COMBATLOG_DEATH)
                 && WARDS_TARGET_NAMES.contains(e.getTargetName());
     }
     


### PR DESCRIPTION
## Summary

Two independent commits:

1. **Cache `FieldPath` lookups in `getEntityProperty`** — clarity's `getFieldPathForName` walks the field tree and allocates a fresh `S2ModifiableFieldPath` on every call, but the (DTClass, property-name) → FieldPath mapping is stable for the lifetime of a parse. Memoizing it eliminates ~5.6M redundant tree walks per Dota replay.

2. **Bump clarity 3.1.3 → 4.0.1.** Source-level changes:
   - `DOTA_COMBATLOG_TYPES` moved from `DOTAUserMessages` into a dedicated `DOTACombatLog` wrapper (clarity-protobuf 5.4 → 6.1) — import swap in 4 files.
   - Custom `OnWardKilled / OnWardExpired / OnWardPlaced` annotations ported to clarity 4.0's typed-event pattern (nested `Listener` + `Event` interfaces, `@GenerateEvent`, `parameterClasses` dropped from `@UsagePointMarker`).
   - `Wards` processor uses the new single-arg `createEvent` and typed `Event` field types.
   - `maven-shade` plugin: `ClassIndexTransformer` (atteo) → `AppendingTransformer` for `META-INF/clarity/providers.txt`. Clarity 4.0 ships its own `EventAnnotationProcessor` that writes per-module provider lists to that path; without the new transformer the shaded jar would only carry clarity's own list and the `Wards` processor wouldn't be discovered at runtime.

## Performance

Bench setup: 195 MB modern Dota S2 replay (`dota/s2/340/8168882574_1198277651.dem`), OpenJDK 21, 2 warmup + 10 timed runs, ByteArrayInputStream → `OutputStream.nullOutputStream()`.

| version                   | median  | vs 3.1.3 baseline |
|---------------------------|---------|-------------------|
| 3.1.3 baseline (today)    | 4.384s  | —                 |
| 3.1.3 + FieldPath cache   | 3.953s  | **−9.8%**         |
| 4.0.1 + FieldPath cache   | 3.609s  | **−17.7%**        |

Numbers above were originally measured on 4.0.0; 4.0.1 is a pure maintenance bump (two missing CS2 decoder registrations + one `CombatLogEntry` accessor) and doesn't touch any Dota hot path, so the figures carry over unchanged.

Spreads under 4% on all configurations; ranges non-overlapping. Cache hit rate 99.97% over 5.6M `getEntityProperty` calls per parse.

## Cosmetic caveat — event casts

`Wards.java` now contains lines like:
\`\`\`java
evKilled = (OnWardKilled.Event) ctx.createEvent(OnWardKilled.class);
\`\`\`
That cast is unfortunate. Clarity 4.0.1's `Context.createEvent` returns `Event<A>` (the base class), but the runtime instance is already the typed subclass. The next clarity release widens the signature to `<E extends Event<A>> E createEvent(Class<A>)`, so the cast disappears with no source change here — just a clarity version bump.

## Looking ahead

The next clarity release brings further improvements that are expected to trim parse time on this workload again. Happy to open a follow-up PR once it ships.

## Test plan

- [ ] \`mvn -DskipTests package\` builds clean.
- [ ] Run against a representative modern S2 replay; JSON-lines output should match 3.1.3 modulo whitespace (no semantic Parse.java changes outside the imports / annotation rewrites).
- [ ] If you have a CI corpus, this PR should not regress it; the FieldPath cache is purely additive and the typed-event port preserves the same listener wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)