### PR TITLE
Detect corrupted zstd replays via exit code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9.12-eclipse-temurin-21-noble
 RUN apt-get update
 
 # Install bzip2/zstd for decompression
-RUN apt-get install bzip2 zstd
+RUN apt-get install -y bzip2 zstd
 
 # Install nodejs for log processing
 # ARG NODE_VERSION=20.10.0

--- a/src/main/java/opendota/Main.java
+++ b/src/main/java/opendota/Main.java
@@ -124,14 +124,19 @@ public class Main {
                     String bzError = new String(bz.getErrorStream().readAllBytes());
                     bz.getErrorStream().close();
                     System.err.println(bzError);
-                    if (bzError.toString().contains("bunzip2: Data integrity error when decompressing") || bzError.contains("bunzip2: Compressed file ends unexpectedly") || bzError.contains("bunzip2: (stdin) is not a bzip2 file")) {
+                    boolean corrupted = bzError.contains("bunzip2: Data integrity error when decompressing") || bzError.contains("bunzip2: Compressed file ends unexpectedly") || bzError.contains("bunzip2: (stdin) is not a bzip2 file");
+                    if (compressor.equals("unzstd")) {
+                        // The zstd magic bytes already matched, so a nonzero exit means a bad file
+                        corrupted = bz.waitFor() != 0;
+                    }
+                    if (corrupted) {
                         // Corrupted replay, don't retry
                         t.sendResponseHeaders(204, 0);
                         t.getResponseBody().close();
                         return;
                     }
                     tEnd = System.currentTimeMillis();
-                    System.err.format("bunzip2: %dms\n", tEnd - tStart);
+                    System.err.format("%s: %dms\n", compressor, tEnd - tStart);
                 }
 
                 // Start parser with input stream created from byte[]


### PR DESCRIPTION
Rebased on top of 83e3d27 — you beat me to the zstd fix, so this PR is now just the small remainder on top of it:

- The corrupted-replay check only matches bunzip2's stderr messages, so a corrupted or truncated zstd replay falls through and feeds garbage to the parser (500 + retries) instead of returning 204 like corrupted bzip2 replays do. Since `unzstd` only runs when the magic bytes already matched, a nonzero exit code means a bad file — so the zstd path now uses the exit code.
- The timing log prints the decompressor actually used instead of a hardcoded `bunzip2:`.
- `apt-get install -y` so the Docker build can't hang on a prompt.

Rebuilt the image from this branch and re-ran a post-cutoff zstd replay (8918058393) end to end: HTTP 200 with full parse output.
