### PR TITLE
Add deaths_log with gold lost and time dead per death

### DIFF
--- a/src/main/java/opendota/CreateParsedDataBlob.java
+++ b/src/main/java/opendota/CreateParsedDataBlob.java
@@ -60,6 +60,7 @@ class PlayerData {
     public List<Entry> sen_left_log = new ArrayList<>();
     public List<Map<String, Object>> purchase_log = new ArrayList<>();
     public List<Map<String, Object>> kills_log = new ArrayList<>();
+    public List<Map<String, Object>> deaths_log = new ArrayList<>();
     public List<Entry> buyback_log = new ArrayList<>();
     public List<Map<String, Object>> runes_log = new ArrayList<>();
     public List<Entry> connection_log = new ArrayList<>();
@@ -357,7 +358,7 @@ public class CreateParsedDataBlob {
         } else if (e.interval != null && e.interval) {
             List<Integer> targetList = getPlayerIntegerList(player, e.type);
             targetList.add(e.value);
-        } else if (Arrays.asList("purchase_log", "kills_log", "runes_log", "neutral_tokens_log").contains(e.type)) {
+        } else if (Arrays.asList("purchase_log", "kills_log", "deaths_log", "runes_log", "neutral_tokens_log").contains(e.type)) {
             Map<String, Object> obj = new HashMap<>();
             obj.put("time", e.time);
             obj.put("key", e.key);
@@ -378,10 +379,19 @@ public class CreateParsedDataBlob {
                 obj.put("smoke", e.smoke);
             }
 
+            if ("deaths_log".equals(e.type)) {
+                obj.put("gold_lost", e.gold_lost);
+                if (e.time_dead != null) {
+                    obj.put("time_dead", e.time_dead);
+                }
+            }
+
             if ("purchase_log".equals(e.type)) {
                 player.purchase_log.add(obj);
             } else if ("kills_log".equals(e.type)) {
                 player.kills_log.add(obj);
+            } else if ("deaths_log".equals(e.type)) {
+                player.deaths_log.add(obj);
             } else if ("runes_log".equals(e.type)) {
                 player.runes_log.add(obj);
             } else if ("neutral_tokens_log".equals(e.type)) {
@@ -516,19 +526,24 @@ public class CreateParsedDataBlob {
     // window. WK's ult does apply a modifier while reincarnating, at the death
     // itself. Both are collected in a pre-scan keyed by event time because the
     // chat, modifier and death entries around a reincarnation are not strictly
-    // ordered in the stream.
+    // ordered in the stream. The same pass collects the deaths_log lookups:
+    // gold lost on death (a separate GOLD record, also not ordered against the
+    // death entry) and the dead stretches, which double as time_dead.
     private static final String WK_HERO = "npc_dota_hero_skeleton_king";
     private static final String WK_REINCARNATION_MODIFIER = "modifier_skeleton_king_reincarnation";
     private static final int AEGIS_EXPIRY_SECONDS = 300;
     // Reincarnation revives in ~3s; the shortest real respawn is far longer,
     // so a WK back on his feet this fast without a buyback reincarnated
     private static final int WK_REVIVE_MAX_SECONDS = 4;
+    // EDOTA_ModifyGold_Reason: 1 = hero death (the negative bucket in gold_reasons)
+    private static final int GOLD_REASON_DEATH = 1;
 
     // aegis pickups: slot -> list of {pickupTime, used}
     private Map<Integer, List<int[]>> aegisPickupsBySlot = new HashMap<>();
     private Map<Integer, List<Integer>> reincarnationTimesBySlot = new HashMap<>();
     private Map<Integer, List<int[]>> deadWindowsBySlot = new HashMap<>();
     private Map<Integer, List<Integer>> buybackTimesBySlot = new HashMap<>();
+    private Map<Integer, Map<Integer, Integer>> deathGoldBySlot = new HashMap<>();
     private Integer wkSlot = null;
 
     private void precomputeReincarnations(List<Entry> entries, Metadata meta) {
@@ -551,6 +566,13 @@ public class CreateParsedDataBlob {
                 }
             } else if ("DOTA_COMBATLOG_BUYBACK".equals(e.type) && e.value != null) {
                 buybackTimesBySlot.computeIfAbsent(e.value, k -> new ArrayList<>()).add(e.time);
+            } else if ("DOTA_COMBATLOG_GOLD".equals(e.type) && e.gold_reason != null
+                    && e.gold_reason == GOLD_REASON_DEATH && e.targetname != null && e.value != null) {
+                Integer slot = meta.hero_to_slot.get(e.targetname);
+                if (slot != null) {
+                    deathGoldBySlot.computeIfAbsent(slot, k -> new HashMap<>())
+                            .merge(e.time, Math.abs(e.value), Integer::sum);
+                }
             } else if ("interval".equals(e.type) && e.slot != null && e.life_state != null) {
                 Integer prev = lastState.get(e.slot);
                 if ((prev == null || prev == 0) && e.life_state != 0) {
@@ -565,6 +587,8 @@ public class CreateParsedDataBlob {
                 lastState.put(e.slot, e.life_state);
             }
         }
+        // deaths still open when the replay ends stay out of deadWindowsBySlot:
+        // their length is unknown, so those deaths get no time_dead
     }
 
     private boolean consumeReincarnationDeath(Integer slot, Integer time) {
@@ -673,6 +697,34 @@ public class CreateParsedDataBlob {
             }
         }
         return false;
+    }
+
+    private Integer lookupDeathGold(Integer slot, Integer time) {
+        Map<Integer, Integer> byTime = slot == null ? null : deathGoldBySlot.get(slot);
+        if (byTime == null || time == null) {
+            return 0;
+        }
+        for (int dt : new int[] { 0, 1, -1, 2, -2 }) {
+            Integer v = byTime.remove(time + dt);
+            if (v != null) {
+                return v;
+            }
+        }
+        return 0;
+    }
+
+    private Integer lookupTimeDead(Integer slot, Integer time) {
+        List<int[]> windows = slot == null ? null : deadWindowsBySlot.get(slot);
+        if (windows == null || time == null) {
+            return null;
+        }
+        for (int[] w : windows) {
+            // the life_state flip shows up on the tick after the death event
+            if (w[0] >= time - 1 && w[0] <= time + 3) {
+                return w[1] - w[0];
+            }
+        }
+        return null;
     }
 
     private List<Entry> processExpand(List<Entry> entries, Metadata meta) {
@@ -896,6 +948,22 @@ public class CreateParsedDataBlob {
 
         if (consumeReincarnationDeath(meta.hero_to_slot.get(key), e.time)) {
             return;
+        }
+
+        if (e.targethero != null && e.targethero &&
+                (e.targetillusion == null || !e.targetillusion)) {
+            // deaths_log includes self-kills (e.g. Techies suicide): the death is
+            // real (it counts on the scoreboard and loses gold) even though no
+            // kill is credited below
+            Entry deathLog = new Entry();
+            deathLog.time = e.time;
+            deathLog.unit = key;
+            deathLog.key = unit;
+            deathLog.type = "deaths_log";
+            Integer victimSlot = meta.hero_to_slot.get(key);
+            deathLog.gold_lost = lookupDeathGold(victimSlot, e.time);
+            deathLog.time_dead = lookupTimeDead(victimSlot, e.time);
+            expand(deathLog, output, meta);
         }
 
         // Suicides (e.g. Techies) are not kills, but only when the attacker is
@@ -1609,7 +1677,7 @@ public class CreateParsedDataBlob {
         return Arrays.asList("times", "gold_t", "lh_t", "dn_t", "xp_t",
                 "camps_stacked_t", "hero_damage_t", "hero_healing_t", "obs_log",
                 "sen_log", "obs_left_log", "sen_left_log", "purchase_log", "kills_log",
-                "buyback_log", "runes_log", "connection_log", "neutral_tokens_log",
+                "deaths_log", "buyback_log", "runes_log", "connection_log", "neutral_tokens_log",
                 "neutral_item_history").contains(type);
     }
 

--- a/src/main/java/opendota/Entry.java
+++ b/src/main/java/opendota/Entry.java
@@ -88,6 +88,9 @@ public class Entry implements Cloneable {
     public String event;
     public Integer killer;
     public Boolean smoke;
+    // deaths_log fields
+    public Integer gold_lost;
+    public Integer time_dead;
 
     public Entry() {
     }


### PR DESCRIPTION
Implements the `deaths_log` half of odota/core#1465: a per-player log of deaths with `{time, key, gold_lost, time_dead}`, where `key` is the killing unit (hero, tower, creep — or the player's own hero for suicides). Also covers odota/core#2294 and odota/core#1780, which ask for the same log.

- `gold_lost` comes from the combat log gold entries with the hero-death reason. It matches `gold_reasons["1"]` exactly per player on the reference replay; on current patches it's 0 since the game removed death gold loss, but historical replays populate it.
- `time_dead` comes from `life_state` transitions in the interval entries (death to respawn, so buybacks shorten it). If the match ends before the respawn, the field is absent rather than guessing. Per player it sums to the dead seconds in the existing `life_state` map.
- Deaths follow the same filters as `killed_by` (real heroes, no illusions, aegis deaths excluded) except self-kills, which are real deaths (they count on the scoreboard and lose gold) even though no kill is credited — e.g. Techies suicides.
- The gold and life_state data are collected in a pre-scan keyed by event time because the combat log death entry, its gold entry and the interval entries around it are not strictly ordered in the stream.

Verified on two replays (the 1781962623 test file and a current-patch match) against the blob's own aggregates and the scoreboard: `deaths_log` length equals scoreboard deaths for all 20 players (including a Techies game: 10 deaths = 7 kills by enemies + 3 suicides), `gold_lost` sums equal `gold_reasons["1"]` for all players, and the rest of the blob is byte-identical to master's output.

On the `assists_log` half of #1465: `CDOTAUserMsg_ChatEvent` does carry the assisters in `playerid_3..6` for hero kill events, but `Parse.java` currently only reads `playerid_1/2` — so it's feasible as a follow-up and I kept it out of this PR to keep the diff small.

Companion core PR: odota/core#2973.
