### PR TITLE
Credit kills by illusions of the victim instead of dropping them as suicides

### DIFF
--- a/src/main/java/opendota/CreateParsedDataBlob.java
+++ b/src/main/java/opendota/CreateParsedDataBlob.java
@@ -792,7 +792,13 @@ public class CreateParsedDataBlob {
             return;
         }
 
-        if (e.attackername != null && e.attackername.equals(key)) {
+        // Suicides (e.g. Techies) are not kills, but only when the attacker is
+        // the victim itself: an illusion OF the victim landing the killing blow
+        // (Dark Portrait, Disruption, Wall of Replica) has the same unit name
+        // while the kill belongs to the illusion's owner, which sourcename
+        // already resolves to
+        if (e.attackername != null && e.attackername.equals(key)
+                && (e.attackerillusion == null || !e.attackerillusion)) {
             return;
         }
 


### PR DESCRIPTION
`kills_log` and `killed_by` drop any kill where the combat log attacker has the same unit name as the victim. That's meant for suicides (Techies), but it also swallows a real kill class: an illusion **of the victim** landing the killing blow — Grimstroke's Dark Portrait, Shadow Demon's Disruption, Wall of Replica. The attacking illusion carries the victim's unit name, so the filter can't tell it apart by name, but `attackerillusion` can: a real suicide is never dealt by an illusion.

Attribution comes out right on its own: `sourcename` already resolves illusion damage to the owning hero (the same mechanism damage counting uses), so the recovered kill lands on the illusion's owner.

Example (reported by a user on Discord): match 8754463676 has radiant score 39, but radiant `kills_log` sums to 38. The missing one is Muerta's death at 2057s, dealt by a Dark Portrait illusion of herself — Grimstroke bought Aghs at 2012s, and his damage map includes `muerta_gunslinger` / `muerta_pierce_the_veil`, which only that illusion can produce. The scoreboard credits Grimstroke with 5 kills; his `kills_log` has 4.

Validation:
- Match 8754463676 reparsed with this branch: the only changes vs master are Grimstroke's `kills_log` 4→5 (adds `{"time": 2057, "key": "npc_dota_hero_muerta"}`), his `killed` map muerta 1→2, Muerta's `killed_by` grimstroke 1→2 (her `killed_by` now sums to her 4 deaths), plus the corresponding teamfight entry. Radiant `kills_log` total becomes 39 = radiant score.
- Regression: the standard test replay (1781962623) produces a byte-identical blob — its 3 suicides are still filtered.

Related: odota/core#1430 is the neighboring case (a tower lands the last hit while the game credits a nearby hero) — that one isn't recoverable from the combat log; this one is.
