### PR TITLE
Annotate kills made from smoke in kills_log

### DIFF
--- a/src/main/java/opendota/CreateParsedDataBlob.java
+++ b/src/main/java/opendota/CreateParsedDataBlob.java
@@ -374,6 +374,10 @@ public class CreateParsedDataBlob {
                 obj.put("tracked_sourcename", e.tracked_sourcename);
             }
 
+            if ("kills_log".equals(e.type) && e.smoke != null) {
+                obj.put("smoke", e.smoke);
+            }
+
             if ("purchase_log".equals(e.type)) {
                 player.purchase_log.add(obj);
             } else if ("kills_log".equals(e.type)) {
@@ -618,10 +622,64 @@ public class CreateParsedDataBlob {
         return false;
     }
 
+    private static final String SMOKE_MODIFIER = "modifier_smoke_of_deceit";
+    // A kill still counts as made from smoke this many seconds after the
+    // modifier broke: the smoke pops on proximity when the gank starts and the
+    // kills land over the following fight. Calibrated against Stratz's isSmoke
+    // label, whose flagged kills fall up to 29s after the break
+    private static final int SMOKE_LINGER_SECONDS = 30;
+    // Defensive close for windows with no remove event (smoke lasts up to 35s)
+    private static final int SMOKE_MAX_SECONDS = 35;
+
+    // Smoke of Deceit windows ([add, remove] of the modifier) by slot,
+    // collected in a pre-scan keyed by event time because the combat log
+    // entries around a kill are not strictly ordered in the stream
+    private Map<Integer, List<int[]>> smokeWindowsBySlot = new HashMap<>();
+
+    private void precomputeSmokeWindows(List<Entry> entries, Metadata meta) {
+        Map<Integer, Integer> openSince = new HashMap<>();
+        for (Entry e : entries) {
+            if (!SMOKE_MODIFIER.equals(e.inflictor) || e.targetname == null || e.time == null) {
+                continue;
+            }
+            Integer slot = meta.hero_to_slot.get(e.targetname);
+            if (slot == null) {
+                continue;
+            }
+            if ("DOTA_COMBATLOG_MODIFIER_ADD".equals(e.type)) {
+                openSince.putIfAbsent(slot, e.time);
+            } else if ("DOTA_COMBATLOG_MODIFIER_REMOVE".equals(e.type)) {
+                Integer start = openSince.remove(slot);
+                if (start != null) {
+                    smokeWindowsBySlot.computeIfAbsent(slot, k -> new ArrayList<>())
+                            .add(new int[] { start, e.time });
+                }
+            }
+        }
+        for (Map.Entry<Integer, Integer> open : openSince.entrySet()) {
+            smokeWindowsBySlot.computeIfAbsent(open.getKey(), k -> new ArrayList<>())
+                    .add(new int[] { open.getValue(), open.getValue() + SMOKE_MAX_SECONDS });
+        }
+    }
+
+    private boolean wasSmoked(Integer slot, Integer time) {
+        List<int[]> windows = slot == null ? null : smokeWindowsBySlot.get(slot);
+        if (windows == null || time == null) {
+            return false;
+        }
+        for (int[] w : windows) {
+            if (time >= w[0] && time <= w[1] + SMOKE_LINGER_SECONDS) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private List<Entry> processExpand(List<Entry> entries, Metadata meta) {
         List<Entry> output = new ArrayList<>();
         precomputeReincarnations(entries, meta);
         precomputeMinuteSeries(entries, meta);
+        precomputeSmokeWindows(entries, meta);
 
         for (Entry e : entries) {
             String type = e.type;
@@ -859,6 +917,9 @@ public class CreateParsedDataBlob {
             killLog.key = key;
             killLog.tracked_death = e.tracked_death;
             killLog.tracked_sourcename = e.tracked_sourcename;
+            if (wasSmoked(meta.hero_to_slot.get(unit), e.time)) {
+                killLog.smoke = true;
+            }
             killLog.type = "kills_log";
             expand(killLog, output, meta);
 

--- a/src/main/java/opendota/Entry.java
+++ b/src/main/java/opendota/Entry.java
@@ -87,6 +87,7 @@ public class Entry implements Cloneable {
     public Boolean interval;
     public String event;
     public Integer killer;
+    public Boolean smoke;
 
     public Entry() {
     }


### PR DESCRIPTION
Adds `smoke: true` to kills_log entries where the killer was under Smoke of Deceit at the kill or up to 30 seconds earlier. Windows come from a pre-scan of the modifier add/remove events keyed by event time (same pattern as the reincarnation pre-scan). Closes odota/core#1477.

The 30s linger isn't arbitrary: the smoke pops when the gank starts and the kills land over the following fight. Calibrated against Stratz's isSmoke label (their flagged kills fall 0-29s after the break) on 2 pro matches, validated on 2 held-out matches plus a fresh one this week: 332/332 kills agree across the 5, zero false positives. With the field stripped the blob is byte-identical to master, and a match with no smokes has zero footprint. Storage cost is a boolean on the handful of smoked kills per match (~9 in a pro game).

odota/web#3369 shows it on the site: a smoke icon on the kill entries in the match log.

![smoke in match log](https://raw.githubusercontent.com/geracosta/web/assets/smoke-log-demo.jpg)