### PR TITLE
Add per-minute net worth series

### DIFF
--- a/src/main/java/opendota/CreateParsedDataBlob.java
+++ b/src/main/java/opendota/CreateParsedDataBlob.java
@@ -51,6 +51,7 @@ class PlayerData {
     public List<Integer> lh_t = new ArrayList<>();
     public List<Integer> dn_t = new ArrayList<>();
     public List<Integer> xp_t = new ArrayList<>();
+    public List<Integer> networth_t = new ArrayList<>();
     public List<Integer> camps_stacked_t = new ArrayList<>();
     public List<Integer> hero_damage_t = new ArrayList<>();
     public List<Integer> hero_healing_t = new ArrayList<>();
@@ -1330,6 +1331,10 @@ public class CreateParsedDataBlob {
                 addIntervalData(e, output, meta, "xp_t", e.xp);
                 addIntervalData(e, output, meta, "lh_t", e.lh);
                 addIntervalData(e, output, meta, "dn_t", e.denies);
+                if (e.networth != null) {
+                    // not present in old replays; leave the array empty rather than filling with nulls
+                    addIntervalData(e, output, meta, "networth_t", e.networth);
+                }
                 if (e.camps_stacked != null) {
                     // not present in old replays; leave the array empty rather than filling with nulls
                     addIntervalData(e, output, meta, "camps_stacked_t", e.camps_stacked);
@@ -1606,7 +1611,7 @@ public class CreateParsedDataBlob {
 
     // Helper methods
     private boolean isArrayField(String type) {
-        return Arrays.asList("times", "gold_t", "lh_t", "dn_t", "xp_t",
+        return Arrays.asList("times", "gold_t", "lh_t", "dn_t", "xp_t", "networth_t",
                 "camps_stacked_t", "hero_damage_t", "hero_healing_t", "obs_log",
                 "sen_log", "obs_left_log", "sen_left_log", "purchase_log", "kills_log",
                 "buyback_log", "runes_log", "connection_log", "neutral_tokens_log",
@@ -1646,6 +1651,8 @@ public class CreateParsedDataBlob {
                 return player.dn_t;
             case "xp_t":
                 return player.xp_t;
+            case "networth_t":
+                return player.networth_t;
             case "camps_stacked_t":
                 return player.camps_stacked_t;
             case "hero_damage_t":


### PR DESCRIPTION
Adds `networth_t`, a per-minute net worth series, next to the existing `gold_t`/`xp_t`/`lh_t`/`dn_t`.

The value is already read from the entity state on every interval tick, it just never makes it into the blob: only the final `net_worth` survives. Someone asked for this on Discord (they wanted net worth over time rather than a single number) and `gold_t` isn't a substitute, since it's total earned gold: at 0:00 net worth is 600 from the starting gold while earned gold is 0, and the two drift further apart with buybacks and consumables.

Semantics match the existing series: samples land on whole minutes, so the last partial minute isn't included. On the match I validated with (42:36), the last sample is at 42:00 and the remaining 36s show up as a gap against Valve's final `net_worth`: negative for players still earning, positive for the three who bought back at the end.

Validation:
- All 10 series line up with `times`/`gold_t` and start at 600.
- With the field stripped the blob is byte-identical to master, on both a current match and the 2015 test replay.
- Replays that don't expose net worth leave the array empty, same as `camps_stacked_t` does today, so old replays cost nothing.

Storage: +1.3 KB gzip per match on that 42 minute game (43441 -> 44792 bytes gzipped).

odota/web#3375 uses it for a Net Worth graph on the Graphs tab, which is the curve every broadcast shows and the site doesn't have yet.